### PR TITLE
[GitHub Actions] release assets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -268,3 +268,44 @@ jobs:
         retention-days: 7
         if-no-files-found: error
 
+  update_assets:
+    name: "Update Assets"
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+           submodules: 'true'
+           fetch-depth: 0
+
+      - name: "Download and merge dist artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: FasterCap*
+          merge-multiple: true
+          path: dist   # destination
+
+      - name: "List dist directory"
+        run: find dist
+
+      - name: "Release dev binaries"
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.ref == 'refs/heads/master'
+        with:
+          name: "Continuous Build: latest development"
+          tag_name: "dev-latest"
+          body: "Build with the latest changes in master."
+          draft: false
+          files: |
+            dist/*
+
+      - name: "Release version binaries"
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            dist/*

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,26 +1,11 @@
 name: Multi-platform C++ build
 
 on:
-  push:
-    branches: [ "master" ]
-    paths-ignore:
-       - '.gitignore'
-       - '**.md'
-       - '*.sh'
-  pull_request:
-    branches: [ "master" ]
-    paths-ignore:
-       - '.gitignore'
-       - '**.md'
-       - '*.sh'
   workflow_call:
-  workflow_dispatch:
-  release:
-    types: [published]
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+# NOTE: concurrency settings must be defined in calling workflow!
+#       otherwise unexpected cancellations will happen
+#   example error: "Canceling since a higher priority waiting request for 'martinjankoehler/klayout-pex-release-v0.1.4-Multi-platform Python/C++ build/test' exists"
 
 jobs:
   build_and_test:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,22 @@
+name: "Latest master run"
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: "Build"
+    uses: ./.github/workflows/ci-cd.yml
+    secrets: inherit
+    permissions:
+      actions: write
+      contents: write

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,25 @@
+name: "Pull Requests"
+run-name: ${{ github.ref_name }} PR
+
+on:
+  push:
+    tags-ignore:
+      - '*'
+    branches-ignore:
+      - master
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: "Build"
+    uses: ./.github/workflows/ci-cd.yml
+    secrets: inherit
+    permissions:
+      actions: write
+      contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: "Build"
+    uses: ./.github/workflows/ci-cd.yml
+    secrets: inherit
+    permissions:
+      actions: write
+      contents: write


### PR DESCRIPTION
- reversion of control: 
  - `ci-cd.yml` now is a reusable workflow
  - starter scripts for PRs, master and release tags then call `ci-cd.yml`